### PR TITLE
文本去重的改进

### DIFF
--- a/src/main/middlewares/TextModifierMiddleware.ts
+++ b/src/main/middlewares/TextModifierMiddleware.ts
@@ -20,7 +20,7 @@ export default class TextInterceptorMiddleware
       if (context.text === '') return
     }
     if (this.deduplicate) {
-      context.text = context.text.replace(/(\S+)\1/g, '$1')
+      context.text = context.text.replace(/(\S+?)\1+/g, '$1')
       if (context.text === '') return
     }
 


### PR DESCRIPTION
有些游戏(比如clockup的yuris引擎)获取到的文本会重复4次, 如果开启deduplicate, 还是会重复两次.
![image](https://user-images.githubusercontent.com/6533064/67629009-cca5ff80-f86f-11e9-9a5f-b82efe53f4ba.png)
这样改的话应该就能解决了