### PR TITLE
feature: enhance text deduplicate

### DIFF
--- a/src/main/config/TextsConfig.ts
+++ b/src/main/config/TextsConfig.ts
@@ -21,7 +21,8 @@ export default class TextsConfig extends Config {
       },
       modifier: {
         removeAscii: false,
-        deduplicate: false
+        deduplicate: false,
+        delineBreak: false
       },
       merger: {
         enable: true,

--- a/src/main/middlewares/TextModifierMiddleware.ts
+++ b/src/main/middlewares/TextModifierMiddleware.ts
@@ -4,10 +4,12 @@ export default class TextInterceptorMiddleware
   implements yuki.Middleware<yuki.TextOutputObject> {
   private removeAscii: boolean
   private deduplicate: boolean
+  private delineBreak: boolean
 
   constructor (config: yuki.Config.Texts['modifier']) {
     this.removeAscii = config.removeAscii
     this.deduplicate = config.deduplicate
+    this.delineBreak = config.delineBreak
     debug('initialized')
   }
 
@@ -20,7 +22,13 @@ export default class TextInterceptorMiddleware
       if (context.text === '') return
     }
     if (this.deduplicate) {
-      context.text = context.text.replace(/(\S+?)\1+/g, '$1')
+      context.text = context.text.replace(/([^]+?)\1+/g, '$1')
+      if (context.text === '') return
+    }
+    if (this.delineBreak) {
+      context.text = context.text.replace('_r', '')
+      context.text = context.text.replace('<br>', '')
+      context.text = context.text.replace(/\s+/g, '')
       if (context.text === '') return
     }
 

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -65,6 +65,7 @@ declare namespace yuki {
       modifier: {
         removeAscii: boolean;
         deduplicate: boolean;
+        delineBreak: boolean;
       }
       merger: {
         enable: boolean;


### PR DESCRIPTION
`(\S+?)\1+` 无法处理含有全角空格的重复句子
![image](https://user-images.githubusercontent.com/28323948/69220740-a181a800-0bb0-11ea-8353-0e05f2cbf2c0.png)

**但是更改之后仍然有bug、如果开头字符一来就有两个是重复的的话也处理不了、**
![image](https://user-images.githubusercontent.com/28323948/69220910-fb826d80-0bb0-11ea-9288-a0591b13314b.png)

加了一项处理特殊字符的开关
应付 用这些换行符的游戏
![image](https://user-images.githubusercontent.com/28323948/69220936-0fc66a80-0bb1-11ea-90c6-3b446c373521.png)
![image](https://user-images.githubusercontent.com/28323948/69221019-3c7a8200-0bb1-11ea-89af-6c966674ad7e.png)

感谢