### PR TITLE
椎名里绪引擎的小毛病

### DIFF
--- a/src/common/IpcTypes.ts
+++ b/src/common/IpcTypes.ts
@@ -34,7 +34,8 @@ enum IpcTypes {
   REQUEST_DICT = 'request-dict',
   HAS_DICT = 'has-dict',
   REQUEST_PROCESSES = 'request-processes',
-  HAS_PROCESSES = 'has-processes'
+  HAS_PROCESSES = 'has-processes',
+  REQUEST_OPEN_FOLDER = 'request-open-folder'
 }
 
 export default IpcTypes

--- a/src/main/middlewares/TextModifierMiddleware.ts
+++ b/src/main/middlewares/TextModifierMiddleware.ts
@@ -32,7 +32,7 @@ export default class TextInterceptorMiddleware
       context.text = context.text.replace(/_r/g, '')
       context.text = context.text.replace(/<br>/g, '')
       context.text = context.text.replace(/\s+/g, '')
-    if (context.text === '') return
+      if (context.text === '') return
     }
 
     next(context)

--- a/src/main/middlewares/TextModifierMiddleware.ts
+++ b/src/main/middlewares/TextModifierMiddleware.ts
@@ -17,6 +17,9 @@ export default class TextInterceptorMiddleware
     context: yuki.TextOutputObject,
     next: (newContext: yuki.TextOutputObject) => void
   ) {
+    context.text = context.text.replace(/[\x00-\x20]/g, '')
+    context.text = context.text.replace(/_t.*?\//g, '')
+
     if (this.removeAscii) {
       context.text = context.text.replace(/[\x00-\xFF]+/g, '')
       if (context.text === '') return
@@ -26,10 +29,10 @@ export default class TextInterceptorMiddleware
       if (context.text === '') return
     }
     if (this.delineBreak) {
-      context.text = context.text.replace('_r', '')
-      context.text = context.text.replace('<br>', '')
+      context.text = context.text.replace(/_r/g, '')
+      context.text = context.text.replace(/<br>/g, '')
       context.text = context.text.replace(/\s+/g, '')
-      if (context.text === '') return
+    if (context.text === '') return
     }
 
     next(context)

--- a/src/main/setup/Ipc.ts
+++ b/src/main/setup/Ipc.ts
@@ -235,6 +235,14 @@ export default function (mainWindow: Electron.BrowserWindow) {
       })
     }
   )
+  
+  ipcMain.on(
+    IpcTypes.REQUEST_OPEN_FOLDER,
+    (event: Electron.Event, gamePath: string) => {
+      const { shell } = require('electron')
+      shell.showItemInFolder(gamePath)
+    }
+  )
 }
 
 function sendConfig (configName: string, event: Electron.Event) {

--- a/src/renderer/components/GamesPageGameCard.vue
+++ b/src/renderer/components/GamesPageGameCard.vue
@@ -21,7 +21,7 @@
   <v-card :elevation="hover ? 8 : 2">
     <v-card-title>{{game.name}}</v-card-title>
     <v-card-subtitle>{{game.code}}</v-card-subtitle>
-    <v-card-text>{{game.path}}</v-card-text>
+    <v-card-text @click="openFolder">{{game.path}}</v-card-text>
     <v-card-actions>
       <v-btn rounded color="primary" min-width="40%" @click.stop="handleRunGame" :loading="showLoaders" :disabled="showLoaders">
         {{$t('run')}}
@@ -150,6 +150,10 @@ export default class HookSettingsHookInfo extends Vue {
 
     ipcRenderer.send(IpcTypes.REQUEST_SAVE_CONFIG, 'games', savingConfig)
     this.$dialog.notify.success(this.$i18n.t('saveSuccess').toString())
+  }
+
+  public openFolder () {
+    ipcRenderer.send(IpcTypes.REQUEST_OPEN_FOLDER, this.game.path)
   }
 
   public beforeMount () {


### PR DESCRIPTION
hook到一些0x20以下的不可打印字符，传到谷歌和彩云经过json.Parse会报错误、`\src\main\translate\Api.ts line 71`
![image](https://user-images.githubusercontent.com/28323948/70388515-da61af80-19ed-11ea-9716-652a915e7983.png)

删掉_txxxxx/形式的日文注音
![注音3](https://user-images.githubusercontent.com/28323948/70388556-8e633a80-19ee-11ea-8b22-7549176eefe4.png)


尝试着照饼画了个打开文件夹的功能，感觉会经常用到
不过想要弄个按钮的，却会卡ui

![ui_crash](https://user-images.githubusercontent.com/28323948/70388543-46441800-19ee-11ea-9bfe-aee24ffee32d.gif)


要是翻译窗口能做成像窗口下面那个buttons-bottom的效果一样就好了，鼠标离开时翻译窗口的标题隐藏，鼠标进入时再显示出来

