### PR TITLE
Add Azure translation API

### DIFF
--- a/config/azureApi.js
+++ b/config/azureApi.js
@@ -1,0 +1,26 @@
+AZURE_TRANSLATION_URL = "https://api.cognitive.microsofttranslator.com/translate?api-version=3.0&to=zh-Hans&from=ja";
+// Get a key at Azure, free 2 million words / month
+SUBSCRIPTION_KEY = "5ce850af5f37474c91e6911ca36ddc24";
+
+requestTranslation = () => {
+  return new Promise((resolve, reject) => {
+    Request.post(AZURE_TRANSLATION_URL, {
+      headers: {
+        "Content-Type": "application/json",
+        "Ocp-Apim-Subscription-Key": SUBSCRIPTION_KEY
+      },
+      json: true,
+      body: [{ Text: text }]
+    }).then(json => {
+      if (json.error) {
+        callback(`Error: ${json.error.message}`);
+      } else {
+        var result = json[0].translations[0].text;
+        callback(result);
+      }
+    }).catch(err => {
+      callback(`error: ${err}`);
+    })
+  })
+}
+requestTranslation();


### PR DESCRIPTION
添加了微软Azure的翻译API，翻译质量一般，比谷歌好一点，可能还是翻译英文有用一点。鉴于翻译质量感觉不需要默认启用。

这个API有一个好处就是可以指定不翻译的词语，这个对未来做共享词典来说方便许多。

文件里自带API key，每月限额2M words。