### PR TITLE
修复 Google 翻译 api

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -44,9 +44,9 @@
       "enable": false,
       "method": "POST",
       "name": "谷歌",
-      "requestBodyFormat": "X{\"q\": %TEXT%, \"sl\": \"ja\", \"tl\": \"zh-CN\"}",
-      "responseBodyPattern": "Rclass=\"t0\">([^<]*)<",
-      "url": "https://translate.google.cn/m"
+      "requestBodyFormat": "X{\"q\": %TEXT%, \"sl\": \"auto\", \"tl\": \"zh-CN\", \"client\": \"at\", \"dt\": \"t\"}",
+      "responseBodyPattern": "R\"(.*?)\"",
+      "url": "https://translate.google.cn/translate_a/single"
     },
     {
       "enable": false,


### PR DESCRIPTION
~~换了一个接口，希望能长久吧——~~
接口已废弃！
与网页版的翻译结果不同！！

（额外的翻译参见 #146） 

![image](https://user-images.githubusercontent.com/20513115/122942994-36f6a680-d3a9-11eb-9e9b-aae909e7f2c8.png)

-----

![image](https://user-images.githubusercontent.com/20513115/122942948-2d6d3e80-d3a9-11eb-8562-e42219541d97.png)
