### PR TITLE
添加DeepL API

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -71,6 +71,14 @@
     },
     {
       "enable": false,
+      "method": "POST",
+      "name": "DeepL",
+      "requestBodyFormat": "X{\"auth_key\":\"#Replace with your auth_key#\",\"text\":%TEXT%,\"target_lang\":\"ZH\"}",
+      "responseBodyPattern": "J%RESPONSE%.translations[0].text",
+      "url": "https://api-free.deepl.com/v2/translate"
+    },
+    {
+      "enable": false,
       "external": true,
       "jsFile": "config\\newBaiduApi.js",
       "name": "百度开放平台"


### PR DESCRIPTION
自用的DeepL API，看有人要就发出来了。自行申请auth_key替换进requestBodyFormat。
注册地址https://www.deepl.com/pro#developer，需要一个海外住址和信用卡完成身份验证，不支持国内。
如果买了付费api，把url改成https://api.deepl.com/v2/translate